### PR TITLE
Move Custom Action within the processing of the period/state checker

### DIFF
--- a/blueprints/automation/panhans/entity_state_persistent_notification.yaml
+++ b/blueprints/automation/panhans/entity_state_persistent_notification.yaml
@@ -338,6 +338,14 @@ action:
       - condition: template
         value_template: "{{ is_period_trigger or trigger.to_state.state == active_state }}"
     then:
+      - variables:
+          custom_action_on: !input custom_action_on
+      - if:
+        - condition: template
+          value_template: "{{ custom_action_on != none }}"
+        then:
+          - choose: []
+            default: !input "custom_action_on"    
       - if:
           - condition: template
             value_template: "{{ notify_device != none }}"
@@ -436,6 +444,14 @@ action:
               message: !input message
               notification_id: "{{ tag }}"
     else:
+      - variables:
+          custom_action_on: !input custom_action_off
+      - if:
+        - condition: template
+          value_template: "{{ custom_action_off != none }}"
+        then:
+          - choose: []
+            default: !input "custom_action_off"
       - service: notify.notify
         data:
           data:
@@ -484,27 +500,5 @@ action:
               s_entity: "{{ sensor }}"
               automation: "{{ this.entity_id }}"
               st_last_changed: "{{ s_last_changed }}"
-
-  - if:
-    - condition: template
-      value_template: "{{ is_period_trigger or trigger.to_state.state == active_state }}"
-    then:
-      - variables:
-          custom_action_on: !input custom_action_on
-      - if:
-        - condition: template
-          value_template: "{{ custom_action_on != none }}"
-        then:
-          - choose: []
-            default: !input "custom_action_on"
-    else:
-      - variables:
-          custom_action_on: !input custom_action_off
-      - if:
-        - condition: template
-          value_template: "{{ custom_action_off != none }}"
-        then:
-          - choose: []
-            default: !input "custom_action_off"
 
 mode: parallel


### PR DESCRIPTION

To fix a bug where the custom action (on) only fires after the timeout period elapses if set.