### PR TITLE
fix: invert factor

### DIFF
--- a/blueprints/automation/panhans/heating_control.yaml
+++ b/blueprints/automation/panhans/heating_control.yaml
@@ -1061,7 +1061,7 @@ trigger_variables:
   input_tweaks: !input input_tweaks
   is_heat_only_if_below_real_temp: "{{ 'heat_only_if_below_real_temp' in input_tweaks}}"
 
-  factor: "{{ iif(input_hvac_mode == 'cool', -1, 1) | int }}"
+  factor: "{{ iif(input_hvac_mode == 'cool', 1, -1) | int }}"
 
 trigger:
   # S Y S T E M   T R I G G E R S
@@ -1523,7 +1523,7 @@ variables:
 
   # E V A L U A T I O N --------------------------------------------------------------
 
-  factor: "{{ iif(input_hvac_mode == 'cool', -1, 1) | int }}"
+  factor: "{{ iif(input_hvac_mode == 'cool', 1, -1) | int }}"
 
   # ------------------------------------------------------------------------------------
   # ------------- PRESENCE, SCHEDULER, FROST PROTECTION, WINDOWS, PERSONS --------------


### PR DESCRIPTION
We are using `factor` to diminish or increase the temperature, by an offset set by the user, when we are away.
In order to reduce the used energy and still maintaing a comfortable environment we should diminish the target temperature when we are heating and increase it when cooling.

This commit changes the current behaviour which is the exact opposite.