### PR TITLE
align filter type for force/eco

### DIFF
--- a/blueprints/automation/panhans/advanced_heating_control.yaml
+++ b/blueprints/automation/panhans/advanced_heating_control.yaml
@@ -316,6 +316,8 @@ blueprint:
               filter:
                 - domain:
                     - input_boolean
+                    - binary_sensor
+                    - timer
               multiple: false
 
         input_force_eco_temperature:
@@ -331,6 +333,8 @@ blueprint:
               filter:
                 - domain:
                     - input_boolean
+                    - binary_sensor
+                    - timer
               multiple: false
 
         input_party_legacy_restore:

--- a/blueprints/automation/panhans/advanced_heating_control.yaml
+++ b/blueprints/automation/panhans/advanced_heating_control.yaml
@@ -317,7 +317,6 @@ blueprint:
                 - domain:
                     - input_boolean
                     - binary_sensor
-                    - timer
               multiple: false
 
         input_force_eco_temperature:
@@ -334,7 +333,6 @@ blueprint:
                 - domain:
                     - input_boolean
                     - binary_sensor
-                    - timer
               multiple: false
 
         input_party_legacy_restore:


### PR DESCRIPTION
The filters for force and eco modes only had `binary_sensor`. But they're not different from `party_mode` which has all 3 boolean domains.

I just added the same for consistentcy and already tested with my set up.