### PR TITLE
Fix latest_entry_xxx to allow filter entires by scheduler string

### DIFF
--- a/blueprints/automation/panhans/advanced_heating_control.yaml
+++ b/blueprints/automation/panhans/advanced_heating_control.yaml
@@ -2494,14 +2494,14 @@ variables:
         | list  %}
 
     {% set selected_entries_days_and_schedule = plan | rejectattr('days','==',Undefined) | selectattr('days','search',current_day) 
-                               | rejectattr('scheduler','==',Undefined) | selectattr('scheduler','in',[scheduler_name]) 
+                               | rejectattr('scheduler','==',Undefined) | selectattr('scheduler','in',scheduler_name) 
                                | list %}
 
     {% set selected_entries_days = plan | rejectattr('days','==',Undefined) | selectattr('days','search',current_day) 
                                         | selectattr('scheduler','in',[Undefined])
                                         | list %}
 
-    {% set selected_entries_schedule = plan | rejectattr('scheduler','==',Undefined) | selectattr('scheduler','in',[scheduler_name]) 
+    {% set selected_entries_schedule = plan | rejectattr('scheduler','==',Undefined) | selectattr('scheduler','in',scheduler_name) 
                                             | selectattr('days','in',[Undefined])
                                             | list %}
 
@@ -2533,14 +2533,14 @@ variables:
         | list  %}
 
     {% set selected_entries_days_and_schedule = plan | rejectattr('days','==',Undefined) | selectattr('days','search',current_day) 
-                               | rejectattr('scheduler','==',Undefined) | selectattr('scheduler','in',[scheduler_name]) 
+                               | rejectattr('scheduler','==',Undefined) | selectattr('scheduler','in',scheduler_name) 
                                | list %}
 
     {% set selected_entries_days = plan | rejectattr('days','==',Undefined) | selectattr('days','search',current_day) 
                                         | selectattr('scheduler','in',[Undefined])
                                         | list %}
 
-    {% set selected_entries_schedule = plan | rejectattr('scheduler','==',Undefined) | selectattr('scheduler','in',[scheduler_name]) 
+    {% set selected_entries_schedule = plan | rejectattr('scheduler','==',Undefined) | selectattr('scheduler','in',scheduler_name) 
                                             | selectattr('days','in',[Undefined])
                                             | list %}
 


### PR DESCRIPTION
This change Fix latest_entry_today and latest_entry_day_before to allow filter entires that contain scheduler string as part of scheduler_name..  Previous implementation is not right with the documentation of Heating Schedule Adjustments, because the scheduler must fully equal to 'Friendly Name' of scheduler selected.