### PR TITLE
Add: implement optional input_number for window open eco temperature control

### DIFF
--- a/blueprints/automation/panhans/advanced_heating_control.yaml
+++ b/blueprints/automation/panhans/advanced_heating_control.yaml
@@ -244,7 +244,7 @@ blueprint:
             > Toggle calibration 
 
             > on/off
-            
+
 
             > 🔘 **mode**
 
@@ -2126,7 +2126,7 @@ variables:
     {% endif %}
 
   window_open_temperature_effective: >
-    {% if (not set_comfort) and window_open_temperature_eco != none %}
+    {% if (not (set_comfort | default(false))) and window_open_temperature_eco != none %}
       {{ window_open_temperature_eco }}
     {% else %}
       {{ input_window_open_temperature }}
@@ -2713,7 +2713,6 @@ variables:
     {% else %}
       {{ 'auto' }}
     {% endif %}
-
 
   #####################################################################################
   ############################### TRIGGER EVALUATION ##################################


### PR DESCRIPTION
I took the liberty to implement an optional input_number for when the window is open, on top of the static eco temperature control. For this feature request: https://github.com/panhans/HomeAssistant/issues/133.

I have tested it on my end and it works. Please review and approve this PR. Thank you very much.