### PR TITLE
FIX(zone_notification_extended): add support for notify entities

### DIFF
--- a/blueprints/automation/panhans/zone_notification_extended.yaml
+++ b/blueprints/automation/panhans/zone_notification_extended.yaml
@@ -345,12 +345,12 @@ variables:
 
   notify_device: !input notify_device
   notify_group: !input notify_group
-  notify_service: |
-    {% if(notify_group is defined and notify_group != '' ) %}
-      notify.{{ notify_group }}
-    {% elif (notify_device != none and notify_device != '' ) %}
-      notify.mobile_app_{{ device_attr(notify_device, "name") | slugify }}
-    {% endif %}
+  notify_service: >-
+    {%- if notify_group is defined and notify_group != '' -%}
+    notify.{{ notify_group | slugify }}
+    {%- elif notify_device != none and notify_device != '' -%}
+    notify.mobile_app_{{ device_attr(notify_device, "name") | slugify }}
+    {%- endif -%}
 
   is_arriving_notification_enabled: !input is_arriving_notification_enabled
   is_leaving_notification_enabled: !input is_leaving_notification_enabled
@@ -415,20 +415,34 @@ action:
     then:
       - variables:
           zone: "{{ zone_from }}"
-      - service: "{{ notify_service }}"
-        data:
-          title: !input title_leaving
-          message: !input message_leaving
-          data:
-            ttl: 0
-            priority: high
-            notification_icon: !input "status_bar_icon"
-            channel: !input "channel"
-            group: !input "group"
-            tag: "{{ tag }}"
-            color: "{{ notification_color_hex }}"
-            vibrationPattern: !input "vibration_pattern"
-            ledColor: "{{led_color_hex}}"
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: "{{ notify_service in states.notify | map(attribute='entity_id') | list }}"
+            sequence:
+              - action: notify.send_message
+                continue_on_error: true
+                target:
+                  entity_id: "{{ notify_service }}"
+                data:
+                  title: !input title_leaving
+                  message: !input message_leaving
+        default:
+          - service: "{{ notify_service }}"
+            continue_on_error: true
+            data:
+              title: !input title_leaving
+              message: !input message_leaving
+              data:
+                ttl: 0
+                priority: high
+                notification_icon: !input "status_bar_icon"
+                channel: !input "channel"
+                group: !input "group"
+                tag: "{{ tag }}"
+                color: "{{ notification_color_hex }}"
+                vibrationPattern: !input "vibration_pattern"
+                ledColor: "{{led_color_hex}}"
 
   - if:
       - condition: template
@@ -450,87 +464,143 @@ action:
             - condition: template
               value_template: "{{ critical_notification }}"
             then:
-            - service: "{{ notify_service }}"
-              data:
-                title: !input title_arriving
-                message: !input message_arriving
-                data:
-                  ttl: 0
-                  priority: high
-                  notification_icon: !input "status_bar_icon"
-                  channel: !input "channel"
-                  group: !input "group"
-                  tag: "{{ tag }}"
-                  color: "{{ notification_color_hex }}"
-                  vibrationPattern: !input "vibration_pattern"
-                  ledColor: "{{led_color_hex}}"
-                  push:
-                    sound:
-                      name: "default"
-                      critical: 1
-                      volume: 1.0
+            - choose:
+                - conditions:
+                    - condition: template
+                      value_template: "{{ notify_service in states.notify | map(attribute='entity_id') | list }}"
+                  sequence:
+                    - action: notify.send_message
+                      continue_on_error: true
+                      target:
+                        entity_id: "{{ notify_service }}"
+                      data:
+                        title: !input title_arriving
+                        message: !input message_arriving
+              default:
+                - service: "{{ notify_service }}"
+                  continue_on_error: true
+                  data:
+                    title: !input title_arriving
+                    message: !input message_arriving
+                    data:
+                      ttl: 0
+                      priority: high
+                      notification_icon: !input "status_bar_icon"
+                      channel: !input "channel"
+                      group: !input "group"
+                      tag: "{{ tag }}"
+                      color: "{{ notification_color_hex }}"
+                      vibrationPattern: !input "vibration_pattern"
+                      ledColor: "{{led_color_hex}}"
+                      push:
+                        sound:
+                          name: "default"
+                          critical: 1
+                          volume: 1.0
             else:
-            - service: "{{ notify_service }}"
-              data:
-                title: !input title_arriving
-                message: !input message_arriving
-                data:
-                  ttl: 0
-                  priority: high
-                  notification_icon: !input "status_bar_icon"
-                  channel: !input "channel"
-                  group: !input "group"
-                  tag: "{{ tag }}"
-                  color: "{{ notification_color_hex }}"
-                  vibrationPattern: !input "vibration_pattern"
-                  ledColor: "{{led_color_hex}}"
+            - choose:
+                - conditions:
+                    - condition: template
+                      value_template: "{{ notify_service in states.notify | map(attribute='entity_id') | list }}"
+                  sequence:
+                    - action: notify.send_message
+                      continue_on_error: true
+                      target:
+                        entity_id: "{{ notify_service }}"
+                      data:
+                        title: !input title_arriving
+                        message: !input message_arriving
+              default:
+                - service: "{{ notify_service }}"
+                  continue_on_error: true
+                  data:
+                    title: !input title_arriving
+                    message: !input message_arriving
+                    data:
+                      ttl: 0
+                      priority: high
+                      notification_icon: !input "status_bar_icon"
+                      channel: !input "channel"
+                      group: !input "group"
+                      tag: "{{ tag }}"
+                      color: "{{ notification_color_hex }}"
+                      vibrationPattern: !input "vibration_pattern"
+                      ledColor: "{{led_color_hex}}"
         else:
           - if:
               - condition: template
                 value_template: "{{ critical_notification }}"
             then:
-              - service: "{{ notify_service }}"
-                data:
-                  title: !input title_arriving
-                  message: !input message_arriving
-                  data:
-                    ttl: 0
-                    priority: high
-                    notification_icon: !input "status_bar_icon"
-                    channel: !input "channel"
-                    group: !input "group"
-                    tag: "{{ tag }}"
-                    color: "{{ notification_color_hex }}"
-                    vibrationPattern: !input "vibration_pattern"
-                    ledColor: "{{led_color_hex}}"
-                    push:
-                      sound:
-                        name: "default"
-                        critical: 1
-                        volume: 1.0
-                    actions:
-                      - action: URI
-                        title: !input custom_button_arriving_text
-                        uri: !input custom_button_arriving_url
+              - choose:
+                  - conditions:
+                      - condition: template
+                        value_template: "{{ notify_service in states.notify | map(attribute='entity_id') | list }}"
+                    sequence:
+                      - action: notify.send_message
+                        continue_on_error: true
+                        target:
+                          entity_id: "{{ notify_service }}"
+                        data:
+                          title: !input title_arriving
+                          message: !input message_arriving
+                default:
+                  - service: "{{ notify_service }}"
+                    continue_on_error: true
+                    data:
+                      title: !input title_arriving
+                      message: !input message_arriving
+                      data:
+                        ttl: 0
+                        priority: high
+                        notification_icon: !input "status_bar_icon"
+                        channel: !input "channel"
+                        group: !input "group"
+                        tag: "{{ tag }}"
+                        color: "{{ notification_color_hex }}"
+                        vibrationPattern: !input "vibration_pattern"
+                        ledColor: "{{led_color_hex}}"
+                        push:
+                          sound:
+                            name: "default"
+                            critical: 1
+                            volume: 1.0
+                        actions:
+                          - action: URI
+                            title: !input custom_button_arriving_text
+                            uri: !input custom_button_arriving_url
             else:
-              - service: "{{ notify_service }}"
-                data:
-                  title: !input title_arriving
-                  message: !input message_arriving
-                  data:
-                    ttl: 0
-                    priority: high
-                    notification_icon: !input "status_bar_icon"
-                    channel: !input "channel"
-                    group: !input "group"
-                    tag: "{{ tag }}"
-                    color: "{{ notification_color_hex }}"
-                    vibrationPattern: !input "vibration_pattern"
-                    ledColor: "{{led_color_hex}}"
-                    actions:
-                      - action: URI
-                        title: !input custom_button_arriving_text
-                        uri: !input custom_button_arriving_url
+              - choose:
+                  - conditions:
+                      - condition: template
+                        value_template: "{{ notify_service in states.notify | map(attribute='entity_id') | list }}"
+                    sequence:
+                      - action: notify.send_message
+                        continue_on_error: true
+                        target:
+                          entity_id: "{{ notify_service }}"
+                        data:
+                          title: !input title_arriving
+                          message: !input message_arriving
+                default:
+                  - service: "{{ notify_service }}"
+                    continue_on_error: true
+                    data:
+                      title: !input title_arriving
+                      message: !input message_arriving
+                      data:
+                        ttl: 0
+                        priority: high
+                        notification_icon: !input "status_bar_icon"
+                        channel: !input "channel"
+                        group: !input "group"
+                        tag: "{{ tag }}"
+                        color: "{{ notification_color_hex }}"
+                        vibrationPattern: !input "vibration_pattern"
+                        ledColor: "{{led_color_hex}}"
+                        actions:
+                          - action: URI
+                            title: !input custom_button_arriving_text
+                            uri: !input custom_button_arriving_url
 
   - if:
       - condition: template


### PR DESCRIPTION
Route notifications through the modern `notify.send_message` action with an entity target when the notify service resolves to a notify entity, falling back to the legacy flat `service:` call inside the choose default otherwise.

Details that make the entity path work:
- Render `notify_service` with a folded scalar (`>-`) and Jinja whitespace control so it produces a clean `notify.<name>` string; the previous literal block leaked newlines/indentation into the value.
- Slugify the group input so display-cased names (e.g. "Iedereen") resolve to the real entity id.
- Detect entities via `states.notify | map(attribute='entity_id')`; `x in states` is false for entities whose state is "unknown" - the resting state of an unused notify group.
- Send only `title` + `message` on the entity path; notify entities reject the rich mobile_app payload (extra keys not allowed). The legacy fallback keeps the full payload.
- Mark all notify steps `continue_on_error: true` so one unreachable local-push target (e.g. a display without an active websocket) doesn't abort the remaining automation steps.